### PR TITLE
bug: attempt to demo potential bug

### DIFF
--- a/tests/derive/main.rs
+++ b/tests/derive/main.rs
@@ -19,6 +19,7 @@ mod groups;
 mod help;
 mod issues;
 mod macros;
+mod mistyped_subcommand;
 mod naming;
 mod nested_subcommands;
 mod non_literal_attributes;

--- a/tests/derive/mistyped_subcommand.rs
+++ b/tests/derive/mistyped_subcommand.rs
@@ -1,0 +1,44 @@
+// Copyright 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(name = "git")]
+struct Git {
+    #[command(subcommand)]
+    cmd: Subcommands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Subcommands {
+    #[command(subcommand)]
+    Remote(RemoteCommand),
+}
+
+#[derive(Parser, Debug)]
+enum RemoteCommand {
+    Add(AddCommand),
+}
+
+#[derive(Parser, Debug, Default, Clone)]
+struct AddCommand {
+    name: String,
+    url: String,
+}
+
+#[test]
+fn test_no_parse() {
+    let result = Git::try_parse_from(["git", "remote", "add", "origin", "git://lol.git"]);
+    assert!(result.is_ok());
+    let result = Git::try_parse_from(["git", "remote", "ad", "origin", "git://lol.git"]);
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    println!("Does this error say that it's on 'remote' or on 'ad'? {error:#?}");
+    println!("If that says the invalid command is 'ad', then clap is working properly, and the error is on our side.");
+}


### PR DESCRIPTION
Investigating whether https://github.com/stellar/soroban-tools/issues/738 is an issue in clap or soroban-cli.

This adds a new test setting up a similar long-chain of subcommands that
soroban-cli uses, and a test mistyping one of the deeply-nested ones.

It appears that clap handles this correctly, so the error must be within
the soroban-cli logic.

Here's the output of the new test when run with `--nocapture`:

```
Does this error say that it's on 'remote' or on 'ad'? ErrorInner {
    kind: InvalidSubcommand,
    context: FlatMap {
        keys: [
            InvalidSubcommand,
            SuggestedSubcommand,
            Suggested,
            Usage,
        ],
        values: [
            String(
                "ad",
            ),
            Strings(
                [
                    "add",
                ],
            ),
            ...
}
If that says the invalid command is 'ad', then clap is working properly, and the error is on our side.
```